### PR TITLE
Add mobile onscreen keyboard

### DIFF
--- a/src/components/OnScreenKeyboard.vue
+++ b/src/components/OnScreenKeyboard.vue
@@ -1,0 +1,36 @@
+<template>
+  <div v-if="settings.store.showOnScreenKeyboard" class="text-center my-2">
+    <div v-if="session.store.state === GameState.Paused">
+      <button class="btn btn-primary" @click="session.resumePlay()">
+        {{ session.store.results.length === 0 ? 'Start' : 'Resume' }}
+      </button>
+    </div>
+    <div v-else-if="session.store.state === GameState.Playing">
+      <div class="mb-2">
+        <button class="btn btn-secondary" @click="session.pausePlay()">Pause</button>
+      </div>
+      <div class="d-flex flex-wrap justify-content-center">
+        <button v-for="letter in letters" :key="letter" class="btn btn-outline-primary m-1"
+                @click="session.submitAnswer(letter)">
+          {{ letter }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import {useSessionStore, GameState} from '@/stores/SessionStore'
+import {useSettingsStore} from '@/stores/SettingsStore'
+
+const session = useSessionStore()
+const settings = useSettingsStore()
+
+const letters = ['A','E','F','G','H','J','N','R','T','U','V','Y','Z']
+</script>
+
+<style scoped>
+button {
+  min-width: 3rem;
+}
+</style>

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -3,11 +3,15 @@ import {defineStore} from 'pinia'
 import {CubeViews, DefaultAllowedCrossColors, DefaultColorScheme, strokeWidthOptions} from "@/scripts/colors";
 import {random_element} from "@/scripts/helpers";
 
+const isMobileDevice = typeof window !== 'undefined' &&
+    ('ontouchstart' in window || navigator.maxTouchPoints > 0);
+
 const defaultSettings = {
     puzzleRotations: CubeViews["Center"],
     strokeWidth: strokeWidthOptions["1"],
     colorScheme: DefaultColorScheme,
-    allowedCrossColors: DefaultAllowedCrossColors
+    allowedCrossColors: DefaultAllowedCrossColors,
+    showOnScreenKeyboard: isMobileDevice
 }
 
 const localStorageKey = "pll_recognition_settings"

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -69,6 +69,15 @@ const customizeColorsVisible = ref(false)
 
     <div class="row my-1">
       <div class="col-6 d-flex align-items-center justify-content-end">
+        Display on-screen keyboard
+      </div>
+      <div class="col-6 text-start">
+        <input type="checkbox" v-model="settings.store.showOnScreenKeyboard" />
+      </div>
+    </div>
+
+    <div class="row my-1">
+      <div class="col-6 d-flex align-items-center justify-content-end">
         Color tones
       </div>
       <div class="col-6 text-start">

--- a/src/views/TrainerView.vue
+++ b/src/views/TrainerView.vue
@@ -6,8 +6,11 @@ import PllCaseInfo from "@/components/PllCaseInfo.vue";
 import {computed, onMounted, onUnmounted} from "vue";
 import {isHelpKey, isPllLetter} from "@/scripts/helpers";
 import ResultsList from "@/components/ResultsList.vue";
+import OnScreenKeyboard from "@/components/OnScreenKeyboard.vue";
+import {useSettingsStore} from "@/stores/SettingsStore";
 
 const session = useSessionStore()
+const settings = useSettingsStore()
 
 const handleKeyPress = e => {
   // if bs modal (.modal.show) or note input (.noteInput) is present, ignore
@@ -55,6 +58,9 @@ onUnmounted(() => {
 })
 
 const keyPressHint = computed(() => {
+  if (settings.store.showOnScreenKeyboard) {
+    return ""
+  }
   if (session.store.state === GameState.Playing && session.store.mistake) {
     return `Press ${session.currentCase.name[0]} to continue, Esc to pause`;
   }
@@ -75,9 +81,10 @@ const keyPressHint = computed(() => {
       <div class="text-center">
         <PllPic :pllCase="session.currentCase" viewType="cube" :size="400" :clickable="false"/>
       </div>
-        <div class="text-secondary text-center my-3">
-          {{ keyPressHint }}
-        </div>
+      <OnScreenKeyboard/>
+      <div class="text-secondary text-center my-3" v-if="!settings.store.showOnScreenKeyboard">
+        {{ keyPressHint }}
+      </div>
       <div v-if="session.store.state === GameState.Playing && session.store.mistake">
         <hr>
         <div class="d-flex justify-content-center">


### PR DESCRIPTION
## Summary
- detect mobile device in settings
- include setting to toggle onscreen keyboard
- add OnScreenKeyboard component with start/resume and PLL letter buttons
- show onscreen keyboard in TrainerView when enabled

## Testing
- `npm run build`